### PR TITLE
added note about map markers

### DIFF
--- a/CleanBuild/style.scss
+++ b/CleanBuild/style.scss
@@ -395,6 +395,7 @@ a[href^="https://maps.google.com/maps"],
 a[href^="https://www.google.com/maps"] {
     display: none !important;
 }
+//remove or comment this out if you use map markers.
 .gmnoprint:not(.gm-bundled-control) {
     display: none;
 }


### PR DESCRIPTION
Map markers are un-clickable with this as display:none, just a note so that it's a bit clearer.