### PR TITLE
Add support for WP 5.x

### DIFF
--- a/CleanBuild/functions/wordpress/wordpress-custom.php
+++ b/CleanBuild/functions/wordpress/wordpress-custom.php
@@ -90,6 +90,7 @@ function has_children() {
 }
 
 // GUTENBERG BLOCKS WHITELIST
+add_filter( 'allowed_block_types', 'gutenbergBlockWhitelist' );
 function gutenbergBlockWhitelist( $allowed_block_types ) {
 
     return array(

--- a/CleanBuild/functions/wordpress/wordpress-custom.php
+++ b/CleanBuild/functions/wordpress/wordpress-custom.php
@@ -89,4 +89,13 @@ function has_children() {
   }
 }
 
+// GUTENBERG BLOCKS WHITELIST
+function gutenbergBlockWhitelist( $allowed_block_types ) {
+
+    return array(
+        'core/freeform' // We're only allowing the Classic Editor
+    );
+
+}
+
 ?>


### PR DESCRIPTION
Obviously security is key, so let's keep everything up-to-date. I know how keen you guys are at Acme Agency for keeping WP Core up to date......

Essentially, I've disabled all the different Gutenberg block options and only enabled "Classic Editor."